### PR TITLE
Refactored Bronya FUA to fix bugs, fixed a BTBIO bug.

### DIFF
--- a/Characters/Bronya.py
+++ b/Characters/Bronya.py
@@ -86,6 +86,12 @@ class Bronya(Character):
         bl.append(Buff("BronyaUltCD", Pwr.CD_PERCENT, e3Mul * self.cdStat + e3Flat, Role.ALL, [AtkType.ALL], 2, 1, Role.SELF, TickDown.END))
         return bl, dbl, al, dl, tl
     
+    def useFua(self, enemyID=-1):
+        bl, dbl, al, dl, tl = super().useFua(enemyID)
+        e5Mul = 1.1 if self.eidolon >= 5 else 1.0
+        tl.append(Turn(self.name, self.role, self.bestEnemy(enemyID), Targeting.SINGLE, [AtkType.FUA, AtkType.BSC], [self.element], [0.8 * e5Mul, 0], [10, 0], 5, self.scaling, 0, "BronyaFUA"))
+        return bl, dbl, al, dl, tl
+
     def handleSpecialStart(self, specialRes: Special):
         self.cdStat = specialRes.attr1
         return super().handleSpecialStart(specialRes)
@@ -96,9 +102,8 @@ class Bronya(Character):
     
     def allyTurn(self, turn: Turn, result: Result):
         bl, dbl, al, dl, tl = super().allyTurn(turn, result)
-        if AtkType.BSC in turn.atkType and turn.moveName not in bonusDMG and self.e4Trigger and result.enemiesHit:
+        if AtkType.BSC in turn.atkType and turn.moveName not in bonusDMG and self.e4Trigger and result.enemiesHit and self.eidolon >= 4:
             self.e4Trigger = False
-            e5Mul = 1.1 if self.eidolon >= 5 else 1.0
-            tl.append(Turn(self.name, self.role, result.enemiesHit[0].enemyID, Targeting.SINGLE, [AtkType.FUA, AtkType.BSC], [self.element], [0.8 * e5Mul, 0], [10, 0], 0, self.scaling, 0, "BronyaFUA"))
+            bl, dbl, al, dl, tl = self.useFua(result.enemiesHit[0].enemyID)
         return bl, dbl, al, dl, tl
     

--- a/Lightcones/Btbio.py
+++ b/Lightcones/Btbio.py
@@ -18,7 +18,7 @@ class Btbio(Lightcone):
     
     def equip(self):
         bl, dbl, al, dl = super().equip()
-        bl.append(Buff("BtbioERR", Pwr.ERR_PERCENT, self.level * 0.02 + 0.8, self.wearerRole))
+        bl.append(Buff("BtbioERR", Pwr.ERR_PERCENT, self.level * 0.02 + 0.08, self.wearerRole))
         return bl, dbl, al, dl
     
     def useSkl(self, enemyID=-1):


### PR DESCRIPTION
This solves Issue #2 .

I refactored the code for Bronya's e4 FUA into a seperate `useFua` function, basing it off of Feixiao's similar functionality as a reference point (although obviously with the extra Feixiao stuff removed). In doing this, along with fixing the mentioned bugs in #2 , the logs now track it as an FUA.

While testing that this fix worked , I discovered that the code for Before The Battle Is Over was causing it to give `level*0.02 + 0.8` energy regen rate, (82%-90%) due to a missing 0, so I fixed that as well.